### PR TITLE
Add: push-scheduled

### DIFF
--- a/.github/workflows/push-compare.yml
+++ b/.github/workflows/push-compare.yml
@@ -1,5 +1,7 @@
 name: Push and compare postgres
 
+# This workflow is required to upgrade several postgres versions from the push-scheduled workflow.
+
 on:
   workflow_call:
     inputs:
@@ -18,6 +20,7 @@ on:
         required: true
       GREENBONE_BOT_TOKEN:
         required: true
+
 jobs:
   compare:
     runs-on:

--- a/.github/workflows/push-compare.yml
+++ b/.github/workflows/push-compare.yml
@@ -27,14 +27,14 @@ jobs:
     steps:
       - name: Compare postgres annotation org.opencontainers.image.created
         id: compare
-        uses: greenbone/actions/oci-info@main
+        uses: greenbone/actions/oci-info@v3
         with:
           command: compare-tag-annotation
           repository: opensight-postgres
           namespace: greenbone
           compare-repository: postgres
           tag: ${{ inputs.postgres-major-version }}
-          mode: gt
+          mode: lt
     outputs:
       compare: ${{ steps.compare.outputs.output }}
 

--- a/.github/workflows/push-compare.yml
+++ b/.github/workflows/push-compare.yml
@@ -23,9 +23,7 @@ on:
 
 jobs:
   compare:
-    runs-on:
-      - self-hosted
-      - self-hosted-generic
+    runs-on: ubuntu-latest
     steps:
       - name: Compare postgres annotation org.opencontainers.image.created
         id: compare

--- a/.github/workflows/push-compare.yml
+++ b/.github/workflows/push-compare.yml
@@ -1,0 +1,42 @@
+name: Push and compare postgres
+
+on:
+  workflow_call:
+    inputs:
+      postgres-major-version:
+        description: "Postgres major version to release."
+        type: string
+        required: true
+
+      charts:
+        description: "Json list with helm charts to upgrade."
+        type: string
+        required: true
+
+jobs:
+  compare:
+    runs-on:
+      - self-hosted
+      - self-hosted-generic
+    steps:
+      - name: Compare postgres annotation org.opencontainers.image.created
+        id: compare
+        uses: greenbone/actions/oci-info@main
+        with:
+          command: compare-tag-annotation
+          repository: opensight-postgres
+          namespace: greenbone
+          compare-repository: postgres
+          tag: ${{ inputs.postgres-major-version }}
+          mode: gt
+    outputs:
+      compare: ${{ steps.compare.outputs.output }}
+
+  push-postgres:
+    needs: compare
+    if: ${{ needs.compare.outputs.compare == 'true' }}
+    uses: ./.github/workflows/push.yml
+    with:
+      postgres-major-version: ${{ inputs.postgres-major-version }}
+      charts: ${{ inputs.charts }}
+    secrets: inherit

--- a/.github/workflows/push-compare.yml
+++ b/.github/workflows/push-compare.yml
@@ -7,12 +7,17 @@ on:
         description: "Postgres major version to release."
         type: string
         required: true
-
       charts:
         description: "Json list with helm charts to upgrade."
         type: string
         required: true
-
+    secrets:
+      COSIGN_KEY_OPENSIGHT:
+        required: true
+      COSIGN_KEY_PASSWORD_OPENSIGHT:
+        required: true
+      GREENBONE_BOT_TOKEN:
+        required: true
 jobs:
   compare:
     runs-on:

--- a/.github/workflows/push-scheduled.yml
+++ b/.github/workflows/push-scheduled.yml
@@ -17,6 +17,9 @@ permissions:
 jobs:
   upgrade-postgres:
     strategy:
+      fail-fast: false
+      # We have to run one workflow after the other here
+      # because our product Helm Chart Construction Process cannot handle multiple processes.
       max-parallel: 1
       matrix:
         include:

--- a/.github/workflows/push-scheduled.yml
+++ b/.github/workflows/push-scheduled.yml
@@ -1,0 +1,29 @@
+name: Push scheduled postgres
+
+# This workflow is necessary because PostgreSQL frequently updates its base image without specifying a patch level.
+# As a result, we must perform weekly checks for any new images.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 3'  # Runs at 00:00 every Wednesday
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  upgrade-postgres:
+    strategy:
+      max-parallel: 1
+      matrix:
+        include:
+          - postgres-major-version: 16
+            charts: '["asset-management-postgres", "opensight-keycloak-postgres", "scan-management-postgres", "vulnerability-intelligence-postgres"]'
+    uses: ./.github/workflows/push-compare.yml
+    with:
+      postgres-major-version: ${{ matrix.postgres-major-version }}
+      charts: ${{ matrix.charts }}
+    secrets: inherit

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -61,7 +61,7 @@ jobs:
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: helm upgrade matrix
+      - name: Helm upgrade matrix
         id: upgrade
         run: |
           echo "matrix=$(echo '${{ inputs.charts }}' | jq -r '{include:[.[] | {chart: ., digest: "${{ inputs.postgres-major-version }}@${{ steps.build.outputs.digest }}" }]} | @json')" >> $GITHUB_OUTPUT

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -82,7 +82,7 @@ jobs:
     steps:
       - name: Get helm chart tags
         id: tags
-        uses: greenbone/actions/oci-info@main
+        uses: greenbone/actions/oci-info@v3
         with:
           repository: helm-charts/opensight-keycloak-postgres
           namespace: greenbone

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,6 +22,13 @@ on:
         description: "Json list with helm charts to upgrade."
         type: string
         required: true
+    secrets:
+      COSIGN_KEY_OPENSIGHT:
+        required: true
+      COSIGN_KEY_PASSWORD_OPENSIGHT:
+        required: true
+      GREENBONE_BOT_TOKEN:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -75,6 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # We have to run one workflow after the other here
+      # because our product Helm Chart Construction Process cannot handle multiple processes.
       max-parallel: 1
       matrix: ${{ fromJSON(needs.push-postgres.outputs.matrix) }}
     steps:
@@ -89,8 +91,10 @@ jobs:
         id: version
         shell: bash
         run: |
+          # Get the latest tag filtered by postgres major version.
           t="$(echo -e '${{ steps.tags.outputs.output }}' | grep -E '${{ inputs.postgres-major-version }}.[0-9]+.[0-9]+' | sort -n | sed q)"
           IFS='.' read -r -a v <<< "$t"
+          # Increment patch level
           v[2]=$((v[2] + 1))
           echo "output=v$(IFS="."; echo "${v[*]// /}")" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -84,7 +84,7 @@ jobs:
         id: tags
         uses: greenbone/actions/oci-info@v3
         with:
-          repository: helm-charts/opensight-keycloak-postgres
+          repository: "helm-charts/${{ matrix.chart }}"
           namespace: greenbone
 
       - name: Increment helm version

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,9 +3,25 @@ name: Build and Push Container
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "Set the postgres version to release."
+      postgres-major-version:
+        description: "Postgres major version to release."
         type: string
+        required: true
+      charts:
+        description: "Json list with helm charts to upgrade."
+        type: string
+        required: true
+
+  workflow_call:
+    inputs:
+      postgres-major-version:
+        description: "Postgres major version to release."
+        type: string
+        required: true
+      charts:
+        description: "Json list with helm charts to upgrade."
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -15,28 +31,77 @@ permissions:
 
 jobs:
   push-postgres:
-    name: Opensight Postgres
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Build and Push
-        id: build-and-push
+        id: build
         uses: greenbone/actions/container-build-push-generic@v3
         with:
-          build-args: "POSTGRES_VERSION=${{ inputs.version }}"
+          build-args: "POSTGRES_VERSION=${{ inputs.postgres-major-version }}"
           cosign-key: ${{ secrets.COSIGN_KEY_OPENSIGHT }}
           cosign-key-password: ${{ secrets.COSIGN_KEY_PASSWORD_OPENSIGHT }}
           cosign-tlog-upload: "false"
           image-url: ${{ github.repository }}
           image-labels: |
             org.opencontainers.image.vendor=Greenbone
-            org.opencontainers.image.base.name=postgres
+            org.opencontainers.image.base.name=postgres:${{ inputs.postgres-major-version }}
           image-tags: |
-            type=raw,value=${{ inputs.version }}
+            type=raw,value=${{ inputs.postgres-major-version }}
           registry: ${{ vars.IMAGE_REGISTRY }}
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Image digest to summary
+
+      - name: helm upgrade matrix
+        id: upgrade
         run: |
-          echo 'Digest: ${{ steps.build-and-push.outputs.digest }}' >> $GITHUB_STEP_SUMMARY
+          echo "matrix=$(echo '${{ inputs.charts }}' | jq -r '{include:[.[] | {chart: ., digest: "${{ inputs.postgres-major-version }}@${{ steps.build.outputs.digest }}" }]} | @json')" >> $GITHUB_OUTPUT
+
+    outputs:
+      matrix: ${{ steps.upgrade.outputs.matrix }}
+
+  push-helm:
+    needs: push-postgres
+    if: ${{ needs.push-postgres.outputs.matrix }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJSON(needs.push-postgres.outputs.matrix) }}
+    steps:
+      - name: Get helm chart tags
+        id: tags
+        uses: greenbone/actions/oci-info@main
+        with:
+          repository: helm-charts/opensight-keycloak-postgres
+          namespace: greenbone
+
+      - name: Increment helm version
+        id: version
+        shell: bash
+        run: |
+          t="$(echo -e '${{ steps.tags.outputs.output }}' | grep -E '${{ inputs.postgres-major-version }}.[0-9]+.[0-9]+' | sort -n | sed q)"
+          IFS='.' read -r -a v <<< "$t"
+          v[2]=$((v[2] + 1))
+          echo "output=v$(IFS="."; echo "${v[*]// /}")" >> $GITHUB_OUTPUT
+
+      - name: Trigger service helm chart upgrade
+        if: ${{ steps.version.outputs.output }}
+        uses: greenbone/actions/trigger-workflow@v3
+        with:
+          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
+          repository: "greenbone/product-helm-chart"
+          workflow: "service-chart-upgrade.yml"
+          inputs: '{"chart": "${{ matrix.chart }}", "chart-version": "${{ steps.version.outputs.output }}", "container-digest": "${{ matrix.digest }}"}'
+
+      - name: Trigger product helm chart upgrade
+        if: ${{ steps.version.outputs.output }}
+        uses: greenbone/actions/trigger-workflow@v3
+        with:
+          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
+          repository: "greenbone/product-helm-chart"
+          workflow: "product-chart-upgrade.yml"
+          inputs: '{"chart": "${{ matrix.chart }}", "tag": "${{ steps.version.outputs.output }}"}'
+


### PR DESCRIPTION
## What
Add: push-scheduled.yml

## Why
This workflow is necessary because PostgreSQL frequently updates its base image without specifying a patch level.
As a result, we must perform weekly checks for any new images.

## References
DEVOPS-877



