### PR TITLE
Add research-vuln-scan workflow

### DIFF
--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -51,39 +51,6 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.grype.outputs.sarif }}
-
-      - name: Run Snyk to check Docker image for vulnerabilities
-        # Snyk can be used to break the build when it detects vulnerabilities.
-        # In this case we want to upload the issues to GitHub Code Scanning
-        continue-on-error: true
-        uses: snyk/actions/docker@14818c4695ecc4045f33c9cee9e795a788711ca4
-        env:
-          # In order to use the Snyk Action you will need to have a Snyk API token.
-          # More details in https://github.com/snyk/actions#getting-your-snyk-token
-          # or you can signup for free at https://snyk.io/login
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          image: "greenbone/opensight-postgres:${{ github.sha }}"
-          args: --file=Dockerfile
-
-      - name: Upload snyk result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: snyk.sarif
-
-      #- name: Analyze for critical and high CVEs
-       # id: docker-scout-cves
-        #if: ${{ github.event_name != 'pull_request_target' }}
-        #uses: docker/scout-action@v1
-        #with:
-         # command: cves, recommendations, compare
-          #image: "greenbone/opensight-postgres:${{ github.sha }}"
-          #sarif-file: sarif.output.json
-          #summary: true
-
-      #- name: Upload docker scout SARIF result
-       # id: upload-sarif
-        #if: ${{ github.event_name != 'pull_request_target' }}
         #uses: github/codeql-action/upload-sarif@v2
         #with:
           #sarif_file: sarif.output.json

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -98,7 +98,7 @@ jobs:
           summary: true
           dockerhub-user: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
-          only-severities: critical, high, medium, low
+          only-severities: critical, high, medium
 
       - name: Upload docker scout SARIF result
         id: upload-sarif

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -52,6 +52,20 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.grype.outputs.sarif }}
-        #uses: github/codeql-action/upload-sarif@v2
-        #with:
-          #sarif_file: sarif.output.json
+
+      - name: Analyze for critical and high CVEs
+        id: docker-scout-cves
+        if: ${{ github.event_name != 'pull_request_target' }}
+        uses: docker/scout-action@v1
+        with:
+          command: cves, recommendations, compare
+          image: "greenbone/opensight-postgres:${{ github.sha }}"
+          sarif-file: sarif.output.json
+          summary: true
+
+      - name: Upload docker scout SARIF result
+        id: upload-sarif
+        if: ${{ github.event_name != 'pull_request_target' }}
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: sarif.output.json

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -65,9 +65,9 @@ jobs:
           # More details in https://github.com/snyk/actions#getting-your-snyk-token
           # or you can signup for free at https://snyk.io/login
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          with:
-            image: "greenbone/opensight-postgres:${{ github.sha }}"
-            args: --file=Dockerfile
+        with:
+          image: "greenbone/opensight-postgres:${{ github.sha }}"
+          args: --file=Dockerfile
 
       - name: Upload snyk result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
         with:
-          image-ref: '${{ vars.GREENBONE_REGISTRY }}opensight/opensight-postgres:16'
+          image-ref: '${{ vars.GREENBONE_REGISTRY }}/opensight/opensight-postgres:16'
           format: 'template'
           template: '@/contrib/sarif.tpl'
           output: 'trivy-results.sarif'
@@ -67,7 +67,7 @@ jobs:
         uses: anchore/scan-action@d5aa5b6cb9414b0c7771438046ff5bcfa2854ed7
         id: grype
         with:
-          image: '${{ vars.GREENBONE_REGISTRY }}opensight/opensight-postgres:16'
+          image: '${{ vars.GREENBONE_REGISTRY }}/opensight/opensight-postgres:16'
           fail-build: false
           severity-cutoff: medium
 
@@ -102,7 +102,7 @@ jobs:
         uses: docker/scout-action@v1
         with:
           command: cves, recommendations, compare
-          image: '${{ vars.GREENBONE_REGISTRY }}opensight/opensight-postgres:16'
+          image: '${{ vars.GREENBONE_REGISTRY }}/opensight/opensight-postgres:16'
           sarif-file: sarif.output.json
           summary: true
           dockerhub-user: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -38,9 +38,9 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'MEDIUM,HIGH,CRITICAL'
           github-pat: ${{ secrets.GITHUB_TOKEN }} # or ${{ secrets.github_pat_name }} if you're using a PAT
-          env:
-            TRIVY_USERNAME: ${{ secrets.GREENBONE_REGISTRY_READ_USER }}
-            TRIVY_PASSWORD: ${{ secrets.GREENBONE_REGISTRY_READ_TOKEN }}
+        env:
+          TRIVY_USERNAME: ${{ secrets.GREENBONE_REGISTRY_READ_USER }}
+          TRIVY_PASSWORD: ${{ secrets.GREENBONE_REGISTRY_READ_TOKEN }}
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@ea9e4e37992a54ee68a9622e985e60c8e8f12d9f # v3.27.4

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -47,8 +47,8 @@ jobs:
         id: grype
         with:
           image: "greenbone/opensight-postgres:${{ github.sha }}"
-          fail-build: true
-          severity-cutoff: critical
+          # fail-build: true
+          # severity-cutoff: critical
 
       - name: Upload grype vulnerability report
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -22,13 +22,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Login to Greenbone Product container registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
-        with:
-          registry: ${{ vars.GREENBONE_REGISTRY }}
-          username: ${{ secrets.GREENBONE_REGISTRY_READ_USER }}
-          password: ${{ secrets.GREENBONE_REGISTRY_READ_TOKEN }}
-
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
         with:

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Build an image from Dockerfile
         run: |

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Upload docker scout SARIF result
         id: upload-sarif
         if: ${{ github.event_name != 'pull_request_target' }}
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: sarif.output.json
           category: ${{ github.jobs[github.job].name }}

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -17,19 +17,22 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     name: Trivy
-    runs-on: "ubuntu-20.04"
+    runs-on: self-hosted-generic
     steps:
       - name: Checkout code
         uses: actions/11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Build an image from Dockerfile
-        run: |
-          docker build -t greenbone/opensight-postgres:${{ github.sha }} .
+      - name: Login to Greenbone Product container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
+        with:
+          registry: ${{ vars.GREENBONE_REGISTRY }}
+          username: ${{ secrets.GREENBONE_REGISTRY_READ_USER }}
+          password: ${{ secrets.GREENBONE_REGISTRY_READ_TOKEN }}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
         with:
-          image-ref: 'greenbone/opensight-postgres:${{ github.sha }}'
+          image-ref: '${{ vars.GREENBONE_REGISTRY }}opensight/opensight-postgres:16'
           format: 'template'
           template: '@/contrib/sarif.tpl'
           output: 'trivy-results.sarif'
@@ -48,20 +51,23 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     name: Grype
-    runs-on: "ubuntu-20.04"
+    runs-on: self-hosted-generic
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Build an image from Dockerfile
-        run: |
-          docker build -t greenbone/opensight-postgres:${{ github.sha }} .
+      - name: Login to Greenbone Product container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
+        with:
+          registry: ${{ vars.GREENBONE_REGISTRY }}
+          username: ${{ secrets.GREENBONE_REGISTRY_READ_USER }}
+          password: ${{ secrets.GREENBONE_REGISTRY_READ_TOKEN }}
 
       - name: Run the Anchore Grype scan action
         uses: anchore/scan-action@d5aa5b6cb9414b0c7771438046ff5bcfa2854ed7
         id: grype
         with:
-          image: "greenbone/opensight-postgres:${{ github.sha }}"
+          image: '${{ vars.GREENBONE_REGISTRY }}opensight/opensight-postgres:16'
           fail-build: false
           severity-cutoff: medium
 
@@ -78,14 +84,17 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
       pull-requests: write
     name: "Docker Scout"
-    runs-on: "ubuntu-20.04"
+    runs-on: self-hosted-generic
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Build an image from Dockerfile
-        run: |
-          docker build -t greenbone/opensight-postgres:${{ github.sha }} .
+      - name: Login to Greenbone Product container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
+        with:
+          registry: ${{ vars.GREENBONE_REGISTRY }}
+          username: ${{ secrets.GREENBONE_REGISTRY_READ_USER }}
+          password: ${{ secrets.GREENBONE_REGISTRY_READ_TOKEN }}
 
       - name: Analyze for critical and high CVEs
         id: docker-scout-cves
@@ -93,7 +102,7 @@ jobs:
         uses: docker/scout-action@v1
         with:
           command: cves, recommendations, compare
-          image: "greenbone/opensight-postgres:${{ github.sha }}"
+          image: '${{ vars.GREENBONE_REGISTRY }}opensight/opensight-postgres:16'
           sarif-file: sarif.output.json
           summary: true
           dockerhub-user: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Upload snyk result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: snyk.sarif
+          sarif_file: build.sarif
 
       - name: Analyze for critical and high CVEs
         id: docker-scout-cves

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -38,6 +38,9 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'MEDIUM,HIGH,CRITICAL'
           github-pat: ${{ secrets.GITHUB_TOKEN }} # or ${{ secrets.github_pat_name }} if you're using a PAT
+          env:
+            TRIVY_USERNAME: ${{ secrets.GREENBONE_REGISTRY_READ_USER }}
+            TRIVY_PASSWORD: ${{ secrets.GREENBONE_REGISTRY_READ_TOKEN }}
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@ea9e4e37992a54ee68a9622e985e60c8e8f12d9f # v3.27.4
@@ -101,7 +104,7 @@ jobs:
         if: ${{ github.event_name != 'pull_request_target' }}
         uses: docker/scout-action@v1
         with:
-          command: cves, recommendations, compare
+          command: cves
           image: '${{ vars.GREENBONE_REGISTRY }}/opensight/opensight-postgres:16'
           sarif-file: sarif.output.json
           summary: true

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -37,7 +37,7 @@ jobs:
           github-pat: ${{ secrets.GITHUB_TOKEN }} # or ${{ secrets.github_pat_name }} if you're using a PAT
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ea9e4e37992a54ee68a9622e985e60c8e8f12d9f # v3.27.4
         with:
           sarif_file: 'trivy-results.sarif'
           category: ${{ github.jobs[github.job].name }}
@@ -66,7 +66,7 @@ jobs:
           severity-cutoff: medium
 
       - name: Upload grype vulnerability report
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ea9e4e37992a54ee68a9622e985e60c8e8f12d9f # v3.27.4
         with:
           sarif_file: ${{ steps.grype.outputs.sarif }}
           category: ${{ github.jobs[github.job].name }}
@@ -103,7 +103,7 @@ jobs:
       - name: Upload docker scout SARIF result
         id: upload-sarif
         if: ${{ github.event_name != 'pull_request_target' }}
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ea9e4e37992a54ee68a9622e985e60c8e8f12d9f # v3.27.4
         with:
           sarif_file: sarif.output.json
           category: ${{ github.jobs[github.job].name }}

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -74,6 +74,7 @@ jobs:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+      pull-requests: write
     name: "Docker Scout"
     runs-on: "ubuntu-20.04"
     steps:

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: self-hosted-generic
     steps:
       - name: Checkout code
-        uses: actions/11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Login to Greenbone Product container registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -68,10 +68,10 @@ jobs:
           image: "greenbone/opensight-postgres:${{ github.sha }}"
           args: --file=Dockerfile
 
-      - name: Upload snyk result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: build.sarif
+      #- name: Upload snyk result to GitHub Code Scanning
+       # uses: github/codeql-action/upload-sarif@v3
+        #with:
+         # sarif_file: snyk.sarif
 
       - name: Analyze for critical and high CVEs
         id: docker-scout-cves

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -1,0 +1,92 @@
+name: trivy & grype & sarif & docker scout vulnerability scan
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  #schedule:
+  #  - cron: '24 23 * * 0'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Build
+    runs-on: "ubuntu-20.04"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build an image from Dockerfile
+        run: |
+          docker build -t greenbone/opensight-postgres:${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
+        with:
+          image-ref: 'greenbone/opensight-postgres:${{ github.sha }}'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+      - name: Run the Anchore Grype scan action
+        uses: anchore/scan-action@d5aa5b6cb9414b0c7771438046ff5bcfa2854ed7
+        id: grype
+        with:
+          image: "greenbone/opensight-postgres:${{ github.sha }}"
+          fail-build: true
+          severity-cutoff: critical
+
+      - name: Upload grype vulnerability report
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.grype.outputs.sarif }}
+
+      - name: Run Snyk to check Docker image for vulnerabilities
+        # Snyk can be used to break the build when it detects vulnerabilities.
+        # In this case we want to upload the issues to GitHub Code Scanning
+        continue-on-error: true
+        uses: snyk/actions/docker@14818c4695ecc4045f33c9cee9e795a788711ca4
+        env:
+          # In order to use the Snyk Action you will need to have a Snyk API token.
+          # More details in https://github.com/snyk/actions#getting-your-snyk-token
+          # or you can signup for free at https://snyk.io/login
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          with:
+            image: "greenbone/opensight-postgres:${{ github.sha }}"
+            args: --file=Dockerfile
+
+      - name: Upload snyk result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: snyk.sarif
+
+      - name: Analyze for critical and high CVEs
+        id: docker-scout-cves
+        if: ${{ github.event_name != 'pull_request_target' }}
+        uses: docker/scout-action@v1
+        with:
+          command: cves, recommendations, compare
+          image: "greenbone/opensight-postgres:${{ github.sha }}"
+          sarif-file: sarif.output.json
+          summary: true
+
+      - name: Upload docker scout SARIF result
+        id: upload-sarif
+        if: ${{ github.event_name != 'pull_request_target' }}
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: sarif.output.json

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -11,65 +11,65 @@ permissions:
   contents: read
 
 jobs:
-#  trivy:
-#    permissions:
-#      contents: read # for actions/checkout to fetch code
-#      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-#      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-#    name: Trivy
-#    runs-on: "ubuntu-20.04"
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v4
-#
-#      - name: Build an image from Dockerfile
-#        run: |
-#          docker build -t greenbone/opensight-postgres:${{ github.sha }} .
-#
-#      - name: Run Trivy vulnerability scanner
-#        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
-#        with:
-#          image-ref: 'greenbone/opensight-postgres:${{ github.sha }}'
-#          format: 'template'
-#          template: '@/contrib/sarif.tpl'
-#          output: 'trivy-results.sarif'
-#          severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
-#          github-pat: ${{ secrets.GITHUB_TOKEN }} # or ${{ secrets.github_pat_name }} if you're using a PAT
-#
-#      - name: Upload Trivy scan results to GitHub Security tab
-#        uses: github/codeql-action/upload-sarif@v3
-#        with:
-#          sarif_file: 'trivy-results.sarif'
-#          category: ${{ github.jobs[github.job].name }}
-#
-#  grype:
-#    permissions:
-#      contents: read # for actions/checkout to fetch code
-#      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-#      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-#    name: Grype
-#    runs-on: "ubuntu-20.04"
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v4
-#
-#      - name: Build an image from Dockerfile
-#        run: |
-#          docker build -t greenbone/opensight-postgres:${{ github.sha }} .
-#
-#      - name: Run the Anchore Grype scan action
-#        uses: anchore/scan-action@d5aa5b6cb9414b0c7771438046ff5bcfa2854ed7
-#        id: grype
-#        with:
-#          image: "greenbone/opensight-postgres:${{ github.sha }}"
-#          fail-build: false
-#          severity-cutoff: low
-#
-#      - name: Upload grype vulnerability report
-#        uses: github/codeql-action/upload-sarif@v3
-#        with:
-#          sarif_file: ${{ steps.grype.outputs.sarif }}
-#          category: ${{ github.jobs[github.job].name }}
+  trivy:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Trivy
+    runs-on: "ubuntu-20.04"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build an image from Dockerfile
+        run: |
+          docker build -t greenbone/opensight-postgres:${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
+        with:
+          image-ref: 'greenbone/opensight-postgres:${{ github.sha }}'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
+          github-pat: ${{ secrets.GITHUB_TOKEN }} # or ${{ secrets.github_pat_name }} if you're using a PAT
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: ${{ github.jobs[github.job].name }}
+
+  grype:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Grype
+    runs-on: "ubuntu-20.04"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build an image from Dockerfile
+        run: |
+          docker build -t greenbone/opensight-postgres:${{ github.sha }} .
+
+      - name: Run the Anchore Grype scan action
+        uses: anchore/scan-action@d5aa5b6cb9414b0c7771438046ff5bcfa2854ed7
+        id: grype
+        with:
+          image: "greenbone/opensight-postgres:${{ github.sha }}"
+          fail-build: false
+          severity-cutoff: low
+
+      - name: Upload grype vulnerability report
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.grype.outputs.sarif }}
+          category: ${{ github.jobs[github.job].name }}
 
   docker-scout:
     permissions:
@@ -98,7 +98,7 @@ jobs:
           summary: true
           dockerhub-user: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
-          # only-severities: -- default is all
+          only-severities: critical, high, medium, low
 
       - name: Upload docker scout SARIF result
         id: upload-sarif

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
-  #schedule:
-  #  - cron: '24 23 * * 0'
 
 permissions:
   contents: read
@@ -68,10 +66,10 @@ jobs:
           image: "greenbone/opensight-postgres:${{ github.sha }}"
           args: --file=Dockerfile
 
-      #- name: Upload snyk result to GitHub Code Scanning
-       # uses: github/codeql-action/upload-sarif@v3
-        #with:
-         # sarif_file: snyk.sarif
+      - name: Upload snyk result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: snyk.sarif
 
       #- name: Analyze for critical and high CVEs
        # id: docker-scout-cves

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -33,7 +33,7 @@ jobs:
           format: 'template'
           template: '@/contrib/sarif.tpl'
           output: 'trivy-results.sarif'
-          severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
+          severity: 'MEDIUM,HIGH,CRITICAL'
           github-pat: ${{ secrets.GITHUB_TOKEN }} # or ${{ secrets.github_pat_name }} if you're using a PAT
 
       - name: Upload Trivy scan results to GitHub Security tab
@@ -63,7 +63,7 @@ jobs:
         with:
           image: "greenbone/opensight-postgres:${{ github.sha }}"
           fail-build: false
-          severity-cutoff: low
+          severity-cutoff: medium
 
       - name: Upload grype vulnerability report
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -11,66 +11,66 @@ permissions:
   contents: read
 
 jobs:
-  trivy:
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    name: Trivy
-    runs-on: "ubuntu-20.04"
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+#  trivy:
+#    permissions:
+#      contents: read # for actions/checkout to fetch code
+#      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+#      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+#    name: Trivy
+#    runs-on: "ubuntu-20.04"
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v4
+#
+#      - name: Build an image from Dockerfile
+#        run: |
+#          docker build -t greenbone/opensight-postgres:${{ github.sha }} .
+#
+#      - name: Run Trivy vulnerability scanner
+#        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
+#        with:
+#          image-ref: 'greenbone/opensight-postgres:${{ github.sha }}'
+#          format: 'template'
+#          template: '@/contrib/sarif.tpl'
+#          output: 'trivy-results.sarif'
+#          severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
+#          github-pat: ${{ secrets.GITHUB_TOKEN }} # or ${{ secrets.github_pat_name }} if you're using a PAT
+#
+#      - name: Upload Trivy scan results to GitHub Security tab
+#        uses: github/codeql-action/upload-sarif@v3
+#        with:
+#          sarif_file: 'trivy-results.sarif'
+#          category: ${{ github.jobs[github.job].name }}
+#
+#  grype:
+#    permissions:
+#      contents: read # for actions/checkout to fetch code
+#      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+#      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+#    name: Grype
+#    runs-on: "ubuntu-20.04"
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v4
+#
+#      - name: Build an image from Dockerfile
+#        run: |
+#          docker build -t greenbone/opensight-postgres:${{ github.sha }} .
+#
+#      - name: Run the Anchore Grype scan action
+#        uses: anchore/scan-action@d5aa5b6cb9414b0c7771438046ff5bcfa2854ed7
+#        id: grype
+#        with:
+#          image: "greenbone/opensight-postgres:${{ github.sha }}"
+#          fail-build: false
+#          severity-cutoff: low
+#
+#      - name: Upload grype vulnerability report
+#        uses: github/codeql-action/upload-sarif@v3
+#        with:
+#          sarif_file: ${{ steps.grype.outputs.sarif }}
+#          category: ${{ github.jobs[github.job].name }}
 
-      - name: Build an image from Dockerfile
-        run: |
-          docker build -t greenbone/opensight-postgres:${{ github.sha }} .
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
-        with:
-          image-ref: 'greenbone/opensight-postgres:${{ github.sha }}'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'trivy-results.sarif'
-          severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
-          github-pat: ${{ secrets.GITHUB_TOKEN }} # or ${{ secrets.github_pat_name }} if you're using a PAT
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: 'trivy-results.sarif'
-          category: ${{ github.jobs[github.job].name }}
-  
-  grype:
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    name: Grype
-    runs-on: "ubuntu-20.04"
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Build an image from Dockerfile
-        run: |
-          docker build -t greenbone/opensight-postgres:${{ github.sha }} .
-
-      - name: Run the Anchore Grype scan action
-        uses: anchore/scan-action@d5aa5b6cb9414b0c7771438046ff5bcfa2854ed7
-        id: grype
-        with:
-          image: "greenbone/opensight-postgres:${{ github.sha }}"
-          fail-build: false
-          severity-cutoff: low
-
-      - name: Upload grype vulnerability report
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: ${{ steps.grype.outputs.sarif }}
-          category: ${{ github.jobs[github.job].name }}
-          
   docker-scout:
     permissions:
       contents: read # for actions/checkout to fetch code

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -33,7 +33,7 @@ jobs:
           format: 'template'
           template: '@/contrib/sarif.tpl'
           output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
+          severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
@@ -46,6 +46,7 @@ jobs:
         with:
           image: "greenbone/opensight-postgres:${{ github.sha }}"
           fail-build: false
+          severity-cutoff: low
 
       - name: Upload grype vulnerability report
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -40,6 +40,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
+          category: ${{ github.jobs[github.job].name }}
   
   grype:
     permissions:
@@ -68,6 +69,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.grype.outputs.sarif }}
+          category: ${{ github.jobs[github.job].name }}
           
   docker-scout:
     permissions:
@@ -104,3 +106,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: sarif.output.json
+          category: ${{ github.jobs[github.job].name }}

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Build an image from Dockerfile
         run: |

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -47,8 +47,7 @@ jobs:
         id: grype
         with:
           image: "greenbone/opensight-postgres:${{ github.sha }}"
-          # fail-build: true
-          # severity-cutoff: critical
+          fail-build: false
 
       - name: Upload grype vulnerability report
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Build an image from Dockerfile
         run: |

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -34,6 +34,7 @@ jobs:
           template: '@/contrib/sarif.tpl'
           output: 'trivy-results.sarif'
           severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
+          github-pat: ${{ secrets.GITHUB_TOKEN }} # or ${{ secrets.github_pat_name }} if you're using a PAT
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -11,12 +11,12 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  trivy:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    name: Build
+    name: Trivy
     runs-on: "ubuntu-20.04"
     steps:
       - name: Checkout code
@@ -40,6 +40,21 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
+  
+  grype:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Grype
+    runs-on: "ubuntu-20.04"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build an image from Dockerfile
+        run: |
+          docker build -t greenbone/opensight-postgres:${{ github.sha }} .
 
       - name: Run the Anchore Grype scan action
         uses: anchore/scan-action@d5aa5b6cb9414b0c7771438046ff5bcfa2854ed7
@@ -53,6 +68,21 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.grype.outputs.sarif }}
+          
+  docker-scout:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: "Docker Scout"
+    runs-on: "ubuntu-20.04"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build an image from Dockerfile
+        run: |
+          docker build -t greenbone/opensight-postgres:${{ github.sha }} .
 
       - name: Analyze for critical and high CVEs
         id: docker-scout-cves

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -93,6 +93,9 @@ jobs:
           image: "greenbone/opensight-postgres:${{ github.sha }}"
           sarif-file: sarif.output.json
           summary: true
+          dockerhub-user: ${{ secrets.DOCKER_USER }}
+          dockerhub-password: ${{ secrets.DOCKER_TOKEN }}
+          # only-severities: -- default is all
 
       - name: Upload docker scout SARIF result
         id: upload-sarif

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -93,8 +93,8 @@ jobs:
           image: "greenbone/opensight-postgres:${{ github.sha }}"
           sarif-file: sarif.output.json
           summary: true
-          dockerhub-user: ${{ secrets.DOCKER_USER }}
-          dockerhub-password: ${{ secrets.DOCKER_TOKEN }}
+          dockerhub-user: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
           # only-severities: -- default is all
 
       - name: Upload docker scout SARIF result

--- a/.github/workflows/research-vuln-scan.yml
+++ b/.github/workflows/research-vuln-scan.yml
@@ -73,19 +73,19 @@ jobs:
         #with:
          # sarif_file: snyk.sarif
 
-      - name: Analyze for critical and high CVEs
-        id: docker-scout-cves
-        if: ${{ github.event_name != 'pull_request_target' }}
-        uses: docker/scout-action@v1
-        with:
-          command: cves, recommendations, compare
-          image: "greenbone/opensight-postgres:${{ github.sha }}"
-          sarif-file: sarif.output.json
-          summary: true
+      #- name: Analyze for critical and high CVEs
+       # id: docker-scout-cves
+        #if: ${{ github.event_name != 'pull_request_target' }}
+        #uses: docker/scout-action@v1
+        #with:
+         # command: cves, recommendations, compare
+          #image: "greenbone/opensight-postgres:${{ github.sha }}"
+          #sarif-file: sarif.output.json
+          #summary: true
 
-      - name: Upload docker scout SARIF result
-        id: upload-sarif
-        if: ${{ github.event_name != 'pull_request_target' }}
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: sarif.output.json
+      #- name: Upload docker scout SARIF result
+       # id: upload-sarif
+        #if: ${{ github.event_name != 'pull_request_target' }}
+        #uses: github/codeql-action/upload-sarif@v2
+        #with:
+          #sarif_file: sarif.output.json


### PR DESCRIPTION
## What
Compare different tools for scanning docker images for CVE's.

## Why
We want to use the best CVE scanner for our docker images: https://jira.greenbone.net/browse/DEVOPS-1249
<!-- Describe why are these changes necessary? -->

## References
https://jira.greenbone.net/browse/DEVOPS-1249
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Comparison list: https://confluence.greenbone.net/display/~robert.schardt/Research+-+Container+image+security+scanners


