### PR TITLE
Ops: Move 'management-console-postgres' to major version 17

### DIFF
--- a/.github/workflows/push-scheduled.yml
+++ b/.github/workflows/push-scheduled.yml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         include:
           - postgres-major-version: 16
-            services: '["vulnerability-intelligence-postgres", "opensight-notification-service-postgres", "management-console-postgres"]'
+            services: '["vulnerability-intelligence-postgres", "opensight-notification-service-postgres"]'
           - postgres-major-version: 17
-            services: '["opensight-keycloak-postgres", "asset-management-postgres"]'
+            services: '["opensight-keycloak-postgres", "asset-management-postgres", "management-console-postgres"]'
     uses: ./.github/workflows/push-compare.yml
     with:
       postgres-major-version: ${{ matrix.postgres-major-version }}


### PR DESCRIPTION
## What
- The "management-console-postgres" service is moved to the "postgres-major-version-17"
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Due to adding an upgrade container for postgres to Management Console, it uses the major version 17.
<!-- Describe why are these changes necessary? -->

## References
T5-1467
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [n./a.] Tests


