### PR TITLE
Fix test and add more docs

### DIFF
--- a/bin/upgradeversion.sh
+++ b/bin/upgradeversion.sh
@@ -39,6 +39,8 @@ fi
 # mitigate: 'you must have read and write access in the current directory'
 cd /var/lib/postgresql
 
+# Once started, pg_upgrade will verify the two clusters are compatible and then do the upgrade.
+# See https://www.postgresql.org/docs/current/pgupgrade.html
 pg_upgrade \
     -U "${POSTGRES_USER}" \
     --old-bindir ${PGBINOLD} \

--- a/tests/test-upgrade.sh
+++ b/tests/test-upgrade.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # attempts to upgrade it and checks if the version file was updated correctly.
 
 DOCKER_IMAGE=packages.greenbone.net/opensight/opensight-postgres
-PREVIOUS_VERSION=16.6  # released version to test the upgrade from
+PREVIOUS_VERSION=16.9.3  # released version to test the upgrade from
 
 tempdir=$(mktemp -d -t opensight-postgres-test-XXXXX)
 
@@ -15,11 +15,11 @@ cleanup() {
 }
 trap cleanup ERR
 
-sudo chown -R 999:999 "${tempdir}"
+sudo chown -R 10002:10002 "${tempdir}"
 
 # Start a PostgreSQL container with an outdated version
 docker run -it --rm \
-  --user 999:999 \
+  --user 10002:10002 \
   -e POSTGRES_PASSWORD=password \
   -e POSTGRES_DB=keycloak \
   -e POSTGRES_USER=keycloak \
@@ -29,7 +29,8 @@ docker run -it --rm \
 # Upgrade the database with the test version
 docker build -t ${DOCKER_IMAGE}:test .
 docker run -it --rm \
-  --user 999:999 -e POSTGRES_PASSWORD=password \
+  --user 10002:10002 \
+  -e POSTGRES_PASSWORD=password \
   -e POSTGRES_DB=keycloak \
   -e POSTGRES_USER=keycloak \
   -v "${tempdir}":/var/lib/postgresql/data \


### PR DESCRIPTION
## What

Fixed the test shell script to use the correct user and group (10002:10002) and updated the docs to reflect that consistency checks are already executed by `pg_upgrade`.

