### PR TITLE
Investigate vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,7 @@ COPY bin/upgradeversion.sh /usr/local/bin/upgradeversion
 
 FROM base AS install
 # Enable and install old version of PostgreSQL.
-RUN sed -i "s/\$/ ${POSTGRES_OLD_VERSION}/" /etc/apt/sources.list.d/pgdg.list
-RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/sources.list
+RUN sed -i "s/\$/ ${POSTGRES_OLD_VERSION}/" /etc/apt/sources.list.d/pgdg.list;
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
@@ -37,12 +36,10 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*;
 
 FROM install AS no-gosu
-
 RUN set -eux; \
     rm -rf /usr/local/bin/gosu;
 
 FROM postgres:${POSTGRES_VERSION} AS su-exec
-
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends gcc libc-dev curl ca-certificates; \
@@ -51,9 +48,7 @@ RUN set -eux; \
     gcc -Wall /usr/local/bin/su-exec.c -o /usr/local/bin/su-exec;
 
 FROM no-gosu AS runtime
-
 COPY --from=su-exec --chown=root:root --chmod=755 /usr/local/bin/su-exec /usr/local/bin/gosu
-
 # We decided to use our own UID range.
 # INFO: https://github.com/greenbone/automatix/blob/main/README.md
 # Change to user root user to run the commands.


### PR DESCRIPTION
## What

~~Bump golang to version 1.23 to mitigate potential security holes.~~
Use 'new' ENV syntax in Dockerfile.

NOTE: Potential security holes come from `gosu`: https://github.com/tianon/gosu/issues/104 . As I dig deeper into this, it seems like the maintainer does check if security holes apply or not. He states that `gosu` **is not vulnerable** and naive security scanners should fix their reporting.

UPDATE: Executed `govulncheck` and gosu seems not to be vulnerable. Instructions: https://github.com/docker-library/postgres/issues/1271#issuecomment-2356959694. I will close the PR and create a new one adding the vulnerability check.

TODOS:
- [x] Remove `gosu` from base image: https://github.com/search?q=repo%3Adocker-library%2Fpostgres%20gosu&type=code
- [x] Replace with https://github.com/ncopa/su-exec
- [ ] Remove backports  and golang-1.23 again as this is not the solution to the issues
- [ ] Test if `postgres` still works properly in `automatix` when using a `gosu` replacement
- [x] Check if `gosu` is really vulnerable (https://github.com/tianon/gosu/blob/4233b796eeb3ba76c8597a46d89eab1f116188e2/SECURITY.md#cves) before using another tool
- [x] Check comment on https://github.com/tianon/gosu/tree/4233b796eeb3ba76c8597a46d89eab1f116188e2?tab=readme-ov-file#su-exec
- [x] Execute `govulncheckwrapper.sh`: https://github.com/docker-library/postgres/issues/1271#issuecomment-2356959694