### PR TITLE
Fix: find for owner change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,14 +23,14 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # The old binaries will be in /usr/lib/postgresql/16/bin
-ENV PGBINOLD /usr/lib/postgresql/${POSTGRES_OLD_VERSION}/bin
-ENV PGBINNEW /usr/lib/postgresql/${POSTGRES_VERSION}/bin
+ENV PGBINOLD=/usr/lib/postgresql/${POSTGRES_OLD_VERSION}/bin
+ENV PGBINNEW=/usr/lib/postgresql/${POSTGRES_VERSION}/bin
 
 # we are usually using /var/lib/postgresql/data as the data directory
 # so this is why we are using it for the 'old' version instead of the
 # path that is customized for the version.
-ENV PGDATAOLD /var/lib/postgresql/data
-ENV PGDATANEW /var/lib/postgresql/${POSTGRES_VERSION}/data
+ENV PGDATAOLD=/var/lib/postgresql/data
+ENV PGDATANEW=/var/lib/postgresql/${POSTGRES_VERSION}/data
 
 COPY bin/upgradeversion.sh /usr/local/bin/upgradeversion
 
@@ -39,6 +39,6 @@ COPY bin/upgradeversion.sh /usr/local/bin/upgradeversion
 # Change to user root user to run the commands.
 USER 0:0
 RUN groupmod -g 10002 postgres && usermod -u 10002 -g 10002 postgres && \
-  find / -uid 999 -not -path "/proc/*" -exec chown 10002 {} \; && \
-  find / -gid 999 -not -path "/proc/*" -exec chown :10002 {} \;
+  find / -path /proc -prune -o -uid 999 -exec chown 10002 {} \; && \
+  find / -path /proc -prune -o -gid 999 -exec chown :10002 {} \;
 USER 10002:10002


### PR DESCRIPTION
## What
- Adjust find cmd for owner change
- Adjust env variable declaration to not throw errors
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
The build of the docker image failed because of the find cmd throwing errors that files could not be found in the `/proc/` directory. And while building the image legacy warnings were shown for the env variable declaration.
<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [N/A] Tests


