### PR TITLE
Fix: Add missing strategy for generating the SBOMs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -101,7 +101,7 @@ jobs:
     needs: push-postgres
     uses: greenbone/workflows/.github/workflows/generate-and-push-sbom-with-trivy-3rd-gen.yml@main
     with:
-      image-url: "${{ vars.GREENBONE_REGISTRY}}/opensight/opensight-postgres:${{ matrix.version }}"
-      output-file-name: 'opensight-postgres.${{ matrix.version }}.sbom.json'
-      artifact-url: "${{ vars.GREENBONE_REGISTRY }}/opensight-dev/opensight-postgres-sbom:${{ matrix.version }}"
+      image-url: "${{ vars.GREENBONE_REGISTRY}}/opensight/opensight-postgres:${{ inputs.version }}"
+      output-file-name: 'opensight-postgres.${{ inputs.version }}.sbom.json'
+      artifact-url: "${{ vars.GREENBONE_REGISTRY }}/opensight-dev/opensight-postgres-sbom:${{ inputs.version }}"
     secrets: inherit


### PR DESCRIPTION
## What
- add missing image version for running the SBOM generation job
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
The version was missing, which led to an error that the postgres image could not be scanned by trivy.
<!-- Describe why are these changes necessary? -->

## References
T5-1437
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [N/A] Tests


