### PR TITLE
change: Upgrade VI- & Notification-Postgres to 17

### DIFF
--- a/.github/workflows/push-scheduled.yml
+++ b/.github/workflows/push-scheduled.yml
@@ -17,10 +17,8 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - postgres-major-version: 16
-            services: '["vulnerability-intelligence-postgres", "opensight-notification-service-postgres"]'
           - postgres-major-version: 17
-            services: '["opensight-keycloak-postgres", "asset-management-postgres", "management-console-postgres"]'
+            services: '["opensight-keycloak-postgres", "asset-management-postgres", "management-console-postgres", "vulnerability-intelligence-postgres", "opensight-notification-service-postgres"]'
     uses: ./.github/workflows/push-compare.yml
     with:
       postgres-major-version: ${{ matrix.postgres-major-version }}


### PR DESCRIPTION
## What
Upgrade vulnerability-intelligence and notification Postgres version from 16 to 17. Add upgrade service for migrations.

## Why
Next step to consolidate all postgres instances

## References
- https://jira.greenbone.net/browse/ARTOSI-559
- https://github.com/greenbone/automatix/pull/698

## Checklist
- [ ] Tests


